### PR TITLE
AUSTA-279: Missing closing '}' in Step "Check Maximum Length of Win10 Hostname on Windows Worker"

### DIFF
--- a/docs/Create-Windows-10-(Win10)-autounattend-Dual-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-10-(Win10)-autounattend-Dual-ISO-on-Windows-Worker.html
@@ -544,9 +544,9 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
         Write-Host &quot;Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}.&quot;
     }
     
-else
+} else {
     Write-Host &quot;Not Win10, skipping.&quot;
-fi
+}
                 </code>
             </pre>
         </div>

--- a/docs/Create-Windows-10-(Win10)-autounattend-Single-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-10-(Win10)-autounattend-Single-ISO-on-Windows-Worker.html
@@ -543,9 +543,9 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
         Write-Host &quot;Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}.&quot;
     }
     
-else
+} else {
     Write-Host &quot;Not Win10, skipping.&quot;
-fi
+}
                 </code>
             </pre>
         </div>

--- a/docs/Perform-Post-Cleanup-on-macOS-or-Linux-Worker.html
+++ b/docs/Perform-Post-Cleanup-on-macOS-or-Linux-Worker.html
@@ -373,7 +373,7 @@ fi
 # The wildcard will allow removal of 
 # - kickstart_{newOsNode.fqn}.iso
 # - drivers_{newOsNode.fqn}.iso
-ISOS={automationWorkerBaseDirectory}/*{newOsNode.fqn}.iso
+ISOS={automationWorkerLinuxBaseDirectory}/*{newOsNode.fqn}.iso
 
 i=0
 for FILE in ${ISOS}

--- a/steps/checkmaximumlengthofwin10hostnameonwindowsworker/script.txt
+++ b/steps/checkmaximumlengthofwin10hostnameonwindowsworker/script.txt
@@ -12,6 +12,6 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
         Write-Host "Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}."
     }
     
-else
+} else {
     Write-Host "Not Win10, skipping."
-fi
+}

--- a/steps/postcleanuponmacosorlinuxworker/script.txt
+++ b/steps/postcleanuponmacosorlinuxworker/script.txt
@@ -17,7 +17,7 @@ fi
 # The wildcard will allow removal of 
 # - kickstart_{newOsNode.fqn}.iso
 # - drivers_{newOsNode.fqn}.iso
-ISOS={automationWorkerBaseDirectory}/*{newOsNode.fqn}.iso
+ISOS={automationWorkerLinuxBaseDirectory}/*{newOsNode.fqn}.iso
 
 i=0
 for FILE in ${ISOS}


### PR DESCRIPTION
Fixed bug in step "Check Maximum Length of Win10 Hostname on Windows Worker".

closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/46.