### PR TITLE
AUSTA-286: Bugfixes for "Create Windows autounattend WinPE ISO on Windows Worker"

### DIFF
--- a/docs/Create-Windows-10-(Win10)-autounattend-Dual-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-10-(Win10)-autounattend-Dual-ISO-on-Windows-Worker.html
@@ -551,10 +551,10 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
     $MAX_LENGTH = 15
     
     if ( $LENGTH -gt $MAX_LENGTH ) {
-        Write-Host &quot;Length of hostname ${LENGTH} for Win10 can&#x27;t be more than ${MAX_LENGTH}.&quot;
+        Write-Host &quot;Length of hostname `&quot;${HOSTNAME}`&quot;  for Win10 is ${LENGTH} and can&#x27;t be more than ${MAX_LENGTH}.&quot;
         false
     } else {
-        Write-Host &quot;Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}.&quot;
+        Write-Host &quot;Length of hostname `&quot;${HOSTNAME}`&quot; for Win10 is ${LENGTH} which is less than or equal to ${MAX_LENGTH}.&quot;
     }
     
 } else {

--- a/docs/Create-Windows-10-(Win10)-autounattend-Single-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-10-(Win10)-autounattend-Single-ISO-on-Windows-Worker.html
@@ -550,10 +550,10 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
     $MAX_LENGTH = 15
     
     if ( $LENGTH -gt $MAX_LENGTH ) {
-        Write-Host &quot;Length of hostname ${LENGTH} for Win10 can&#x27;t be more than ${MAX_LENGTH}.&quot;
+        Write-Host &quot;Length of hostname `&quot;${HOSTNAME}`&quot;  for Win10 is ${LENGTH} and can&#x27;t be more than ${MAX_LENGTH}.&quot;
         false
     } else {
-        Write-Host &quot;Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}.&quot;
+        Write-Host &quot;Length of hostname `&quot;${HOSTNAME}`&quot; for Win10 is ${LENGTH} which is less than or equal to ${MAX_LENGTH}.&quot;
     }
     
 } else {

--- a/docs/Create-Windows-PE-(WinPE)-Plain-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-PE-(WinPE)-Plain-ISO-on-Windows-Worker.html
@@ -310,8 +310,8 @@
         
 
                     <p class="text-muted pt-2">
-                        <a href="#overwritebootwimwithbootcleanedwimonwindowsworker">
-                            <strong>Step 9.5 -</strong> Overwrite BOOT.WIM with BOOT_CLEANED.WIM on Windows Worker
+                        <a href="#overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker">
+                            <strong>Step 9.5 -</strong> Overwrite BOOT.WIM with BOOT_CLEANED.WIM from build-winpe-iso on Windows Worker
                         </a>
                     </p>
 
@@ -1105,7 +1105,7 @@ if ( -Not (Test-Path &quot;${WinPE_BootImageDir}&quot;) ) {
                     <div class="row">
                         <div class="description col px-0">
                             <p>
-                                <p>Mounts <code>C:\attuneautomationworker\build-winpe-iso\winpe_staging\SOURCES\BOOT.WIM</code> to <code>C:\attuneautomationworker\build-winpe-iso\WinPE_BootImageDir</code> using <code>Dism</code>.</p>
+                                <p>Mounts <code>C:\attuneautomationworker\build-winpe-iso\winpe_staging\SOURCES\BOOT.WIM</code> to <code>C:\attuneautomationworker\build-winpe-iso\WinPE_BootImageDir</code> using <code>Dism</code> on Windows Worker.</p>
                             </p>
                         </div>
                     </div>
@@ -1303,9 +1303,9 @@ Dism /Export-Image /SourceImageFile:&quot;./winpe_staging/SOURCES/BOOT.WIM&quot;
 
 
                     <div class="row pt-5">
-                        <h4 id="overwritebootwimwithbootcleanedwimonwindowsworker">
-                            <a href="#overwritebootwimwithbootcleanedwimonwindowsworker">
-                                <strong>Step 9.5 -</strong> Overwrite BOOT.WIM with BOOT_CLEANED.WIM on Windows Worker
+                        <h4 id="overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker">
+                            <a href="#overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker">
+                                <strong>Step 9.5 -</strong> Overwrite BOOT.WIM with BOOT_CLEANED.WIM from build-winpe-iso on Windows Worker
                             </a>
                         </h4>
                     </div>
@@ -1314,6 +1314,7 @@ Dism /Export-Image /SourceImageFile:&quot;./winpe_staging/SOURCES/BOOT.WIM&quot;
                         <div class="description col px-0">
                             <p>
                                 <p>Overwrites <code>BOOT.WIM</code> with <code>BOOT_CLEANED.WIM</code> and deletes <code>BOOT_CLEANED.WIM</code>.</p>
+<p>This is relative to the <code>C:\attuneautomationworker\build-winpe-iso\winpe_staging\SOURCES</code> folder.</p>
                             </p>
                         </div>
                     </div>

--- a/docs/Create-Windows-autounattend-WinPE-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-autounattend-WinPE-ISO-on-Windows-Worker.html
@@ -413,6 +413,14 @@
                         </a>
                     </p>
 
+        
+
+                    <p class="text-muted pt-2">
+                        <a href="#overwritebootwimwithbootcleanedwimonwindowsworker">
+                            <strong>Step 15.5 -</strong> Overwrite BOOT.WIM with BOOT_CLEANED.WIM on Windows Worker
+                        </a>
+                    </p>
+
 
         
 
@@ -589,16 +597,16 @@ if ( -Not ${{isWinPEKickstart}} ) {
     exit 1
 }
 
-if ( {windowsFolderOnSamba} -eq &quot;windows10&quot; ) {
+if ( &quot;{windowsFolderOnSamba}&quot; -eq &quot;windows10&quot; ) {
     if ( (-Not ${{isWin10Bios}}) -And (-Not ${{isWin10Uefi}}) ) {
         Write-Host &quot;Please set one of &#x27;isWin10Bios&#x27; or &#x27;isWin10Uefi&#x27; to true to install Win10.&quot;
         exit 1
     }
 }
 
-if (( {windowsFolderOnSamba} -eq &quot;windows2016&quot; ) -Or
-    ( {windowsFolderOnSamba} -eq &quot;windows2019&quot; ) -Or
-    ( {windowsFolderOnSamba} -eq &quot;windows2022&quot; )) {
+if (( &quot;{windowsFolderOnSamba}&quot; -eq &quot;windows2016&quot; ) -Or
+    ( &quot;{windowsFolderOnSamba}&quot; -eq &quot;windows2019&quot; ) -Or
+    ( &quot;{windowsFolderOnSamba}&quot; -eq &quot;windows2022&quot; )) {
 
     if ( (-Not ${{isWinServerBios}}) -And (-Not ${{isWinServerUefi}}) ) {
         Write-Host &quot;Please set one of &#x27;isWinServerBios&#x27; or &#x27;isWinServerUefi&#x27; to true to install Windows Server.&quot;
@@ -822,10 +830,10 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
     $MAX_LENGTH = 15
     
     if ( $LENGTH -gt $MAX_LENGTH ) {
-        Write-Host &quot;Length of hostname ${LENGTH} for Win10 can&#x27;t be more than ${MAX_LENGTH}.&quot;
+        Write-Host &quot;Length of hostname `&quot;${HOSTNAME}`&quot;  for Win10 is ${LENGTH} and can&#x27;t be more than ${MAX_LENGTH}.&quot;
         false
     } else {
-        Write-Host &quot;Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}.&quot;
+        Write-Host &quot;Length of hostname `&quot;${HOSTNAME}`&quot; for Win10 is ${LENGTH} which is less than or equal to ${MAX_LENGTH}.&quot;
     }
     
 } else {
@@ -1051,7 +1059,7 @@ for ($i = 0; $i -lt 4; $i++) {
                     <div class="row">
                         <div class="description col px-0">
                             <p>
-                                <p>Checks if the WinPE plain BIOS ISO <code>C:\attuneautomationworker/winpe_plain_bios.iso</code> exists.</p>
+                                <p>Checks if the WinPE plain BIOS ISO <code>C:\attuneautomationworker\winpe_plain_bios.iso</code> exists.</p>
 <p>If it does not, a message will be printed to ask the user to run the WinPE BIOS ISO creation blueprint <code>Create Windows PE (WinPE) Plain ISO on Windows Worker</code>.</p>
 <p>Only applies to BIOS kickstarts so if any of these parameters are set the string <code>true</code>:</p>
 <ol>
@@ -1127,7 +1135,7 @@ if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
                     <div class="row">
                         <div class="description col px-0">
                             <p>
-                                <p>Checks if the WinPE plain BIOS ISO <code>C:\attuneautomationworker/winpe_plain_uefi.iso</code> exists.</p>
+                                <p>Checks if the WinPE plain BIOS ISO <code>C:\attuneautomationworker\winpe_plain_uefi.iso</code> exists.</p>
 <p>If it does not, a message will be printed to ask the user to run the WinPE UEFI ISO creation blueprint <code>Create Windows PE (WinPE) Plain ISO on Windows Worker</code>.</p>
 <p>Only applies to BIOS kickstarts so if any of these parameters are set the string <code>true</code>:</p>
 <ol>
@@ -1257,7 +1265,7 @@ if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
     }
 
     Copy-Item -Path &quot;winpe_plain_bios.iso&quot; `
-        -Destination &quot;${BUILD_FOLDER}&quot;
+        -Destination &quot;${BUILD_FOLDER}\winpe.iso&quot;
     
 } else {
     Write-Host &quot;Skipping for UEFI ISO creation.&quot;
@@ -1340,7 +1348,7 @@ if ( ${{isWin10Uefi}} -Or ${{isWinServerUefi}} ) {
     }
 
     Copy-Item -Path &quot;winpe_plain_uefi.iso&quot; `
-        -Destination &quot;${BUILD_FOLDER}&quot;
+        -Destination &quot;${BUILD_FOLDER}\winpe.iso&quot;
     
 } else {
     Write-Host &quot;Skipping for BIOS ISO creation.&quot;
@@ -1695,7 +1703,7 @@ Set-Location $BUILD_DIR
 $POST_INSTALL_WIM_FOLDER = &quot;post_install_wim&quot;
 
 if ( -Not (Test-Path &quot;${POST_INSTALL_WIM_FOLDER}&quot;) ) {
-  New-Item &quot;${POST_INSTALL_WIM_FOLDER} -ItemType Directory
+  New-Item &quot;${POST_INSTALL_WIM_FOLDER}&quot; -ItemType Directory
 }
 
 Move-Item -Path .\post_install_setup.ps1 `
@@ -1760,8 +1768,8 @@ Set-Location $BUILD_DIR
 
 Write-Host &quot;We are in ${BUILD_DIR}&quot;
 
-SOURCE=&quot;post_install_wim&quot;
-WIMFILE=&quot;post_install.wim&quot;
+$SOURCE=&quot;post_install_wim&quot;
+$WIMFILE=&quot;post_install.wim&quot;
 
 Write-Host &quot;Creating ${WIMFILE} from directory ${SOURCE}.&quot;
 
@@ -1882,7 +1890,7 @@ Set-Location &quot;${BUILD_DIR}&quot;
 $WinPE_BootImageDir=&quot;WinPE_BootImageDir&quot;
 
 if ( -Not (Test-Path &quot;${WinPE_BootImageDir}&quot;) ) {
-  New-Item &quot;${WinPE_BootImageDi}&quot; -ItemType Directory
+  New-Item &quot;${WinPE_BootImageDir}&quot; -ItemType Directory
 }
                 </code>
             </pre>
@@ -1908,7 +1916,7 @@ if ( -Not (Test-Path &quot;${WinPE_BootImageDir}&quot;) ) {
                     <div class="row">
                         <div class="description col px-0">
                             <p>
-                                <p>In the <code>C:\attuneautomationworker\build-{newOsNode.fqn}</code> folder, mounts <code>winpe_staging\SOURCES\BOOT.WIM</code> to <code>WinPE_BootImageDir</code> on Windows Worker.</p>
+                                <p>In the <code>C:\attuneautomationworker\build-{newOsNode.fqn}</code> folder, mounts <code>winpe_staging\SOURCES\BOOT.WIM</code> to <code>WinPE_BootImageDir</code> using <code>Dism</code> on Windows Worker.</p>
                             </p>
                         </div>
                     </div>
@@ -1942,24 +1950,13 @@ $BUILD_DIR=&quot;$ISO_BUILD\build-{newOsNode.fqn}&quot;
 
 Set-Location $BUILD_DIR
 
-$scriptContent=@&quot;
-wimmountrw winpe_staging/SOURCES/BOOT.WIM WinPE_BootImageDir
-&quot;@
-
-# Replace CRLF with LF
-$scriptContent = $scriptContent.replace(&quot;`r`n&quot;,&quot;`n&quot;)
-    
-$FILE = &quot;attune_wsl_mount_boot_wim.sh&quot;
-
-Set-Content -Path $FILE -NoNewline -Value $scriptContent
-
-wsl -d Ubuntu --user {wsl2AutomationWorkerLinuxUser.user} --exec bash &quot;${FILE}&quot;
-
+Dism /Mount-Image /ImageFile:&quot;./winpe_staging/SOURCES/BOOT.WIM&quot; `
+  /Index:1 `
+  /MountDir:&quot;./WinPE_BootImageDir&quot;
+  
 if ($LASTEXITCODE -ne 0) {
     Write-Error &#x27;Failed to mount BOOT.WIM&#x27;
 }
-  
-Remove-Item &quot;${FILE}&quot;
                 </code>
             </pre>
         </div>
@@ -2052,8 +2049,12 @@ $BUILD_DIR=&quot;${ISO_BUILD}\build-{newOsNode.fqn}&quot;
 
 Set-Location &quot;${BUILD_DIR}&quot;
 
+$DESTINATION_FILE = &quot;.\WinPE_BootImageDir\Windows\System32\startnet.cmd&quot;
+
+Remove-Item &quot;${DESTINATION_FILE}&quot;
+
 Move-Item -Path &quot;.\startnet.cmd&quot; `
-    -Destination &quot;.\WinPE_BootImageDir\Windows\System32&quot;
+    -Destination &quot;${DESTINATION_FILE}&quot;
                 </code>
             </pre>
         </div>
@@ -2176,7 +2177,7 @@ Set-Location &quot;${BUILD_DIR}\${WinPE_BootImageDir}&quot;
 
 $DRIVERS=&quot;drivers&quot;
 if ( -Not (Test-Path &quot;${DRIVERS}&quot;) ) {
-  New-Item DRIVERS -ItemType Directory
+  New-Item &quot;${DRIVERS}&quot; -ItemType Directory
 }
 
 $DRIVERS_DROP_IN_FOLDER=&quot;C:\attuneautomationworker\drivers-{newOsNode.fqn}&quot;
@@ -2273,8 +2274,18 @@ Move-Item -Path &quot;.\post_install.wim&quot; `
                     <div class="row">
                         <div class="description col px-0">
                             <p>
-                                <p>Unmounts <code>C:\attuneautomationworker\build-{newOsNode.fqn}\WinPE_BootImageDir</code> using <code>wimunmount</code> on Windows Worker with WSL2.</p>
-<p>This will write out changes back into <code>winpe_staging\SOURCES\BOOT.WIM</code>.</p>
+                                <p>Unmounts <code>C:\attuneautomationworker\build-{newOsNode.fqn}\WinPE_BootImageDir</code> using <code>Dism</code>.</p>
+<p>This will write out changes back into <code>C:\attuneautomationworker\winpe_staging\SOURCES\BOOT.WIM</code>.</p>
+<p>Then a compressed version of <code>BOOT.WIM</code> is generated called <code>BOOT_CLEANED.WIM</code>.</p>
+<p>Make sure there is no Windows File Explorer open at the mount directory.</p>
+<p>If there is the unmount will fail and you need to run these commands to unmount it:</p>
+<pre><code>$ISO_BUILD=&quot;C:\attuneautomationworker&quot;
+$BUILD_DIR=&quot;$ISO_BUILD\build-{newOsNode.fqn}&quot;
+
+Set-Location $BUILD_DIR
+
+Dism /Unmount-Image /MountDir:&quot;./WinPE_BootImageDir&quot; /discard
+</code></pre>
                             </p>
                         </div>
                     </div>
@@ -2310,24 +2321,91 @@ Set-Location &quot;${BUILD_DIR}&quot;
 
 $WinPE_BootImageDir = &quot;WinPE_BootImageDir&quot;
 
-$scriptContent=@&quot;
-wimunmount &quot;${WinPE_BootImageDir}&quot; --commit --check --rebuild
-&quot;@
-
-# Replace CRLF with LF
-$scriptContent = $scriptContent.replace(&quot;`r`n&quot;,&quot;`n&quot;)
+Dism /Image:&quot;./WinPE_BootImageDir&quot; `
+    /cleanup-image `
+    /StartComponentCleanup `
+    /ResetBase
     
-$FILE = &quot;attune_wsl_unmount_boot_wim.sh&quot;
+# Unmount the WinPE_BootImageDir folder back into BOOT.WIM
+Dism /Unmount-Image /MountDir:&quot;./WinPE_BootImageDir&quot; /Commit
 
-Set-Content -Path $FILE -NoNewline -Value $scriptContent
+# Generate a compressed version of BOOT.WIM called BOOT_CLEANED.WIM
+Dism /Export-Image /SourceImageFile:&quot;./winpe_staging/SOURCES/BOOT.WIM&quot; `
+  /SourceIndex:1 `
+  /DestinationImageFile:&quot;./winpe_staging/SOURCES/BOOT_CLEANED.WIM&quot; `
+  /Compress:max `
+  /Bootable `
+  /CheckIntegrity
+                </code>
+            </pre>
+        </div>
+    </div>
 
-wsl -d Ubuntu --user {wsl2AutomationWorkerLinuxUser.user} --exec bash &quot;${FILE}&quot;
 
-if ($LASTEXITCODE -ne 0) {
-    Write-Error &#x27;Failed to unmount $BUILD_DIR\${WinPE_BootImageDir}&#x27;
-}
-  
-Remove-Item &quot;${FILE}&quot;
+
+
+
+    
+
+
+
+                    <div class="row pt-5">
+                        <h4 id="overwritebootwimwithbootcleanedwimonwindowsworker">
+                            <a href="#overwritebootwimwithbootcleanedwimonwindowsworker">
+                                <strong>Step 15.5 -</strong> Overwrite BOOT.WIM with BOOT_CLEANED.WIM on Windows Worker
+                            </a>
+                        </h4>
+                    </div>
+
+                    <div class="row">
+                        <div class="description col px-0">
+                            <p>
+                                <p>Overwrites <code>BOOT.WIM</code> with <code>BOOT_CLEANED.WIM</code> and deletes <code>BOOT_CLEANED.WIM</code>.</p>
+                            </p>
+                        </div>
+                    </div>
+
+
+
+
+
+
+
+
+
+    
+
+
+    
+
+
+
+    <div class="row">
+        <p>
+            Execute the following script:
+        </p>
+    </div>
+    <div class="row">
+        <div class="col px-0">
+            <pre>
+                <code class="language-sql py-0">
+$ISO_BUILD=&quot;C:\attuneautomationworker&quot;
+$WINPE_STAGING_SOURCES_DIR=&quot;$ISO_BUILD\build-{newOsNode.fqn}\winpe_staging\SOURCES&quot;
+
+Set-Location &quot;${WINPE_STAGING_SOURCES_DIR}&quot;
+
+Write-Host &quot;Before&quot;
+dir
+
+$BOOT_CLEANED_WIM=&quot;BOOT_CLEANED.WIM&quot;
+
+Copy-Item -Path &quot;.\${BOOT_CLEANED_WIM}&quot; `
+    -Destination &quot;.\BOOT.WIM&quot;
+    
+Remove-Item &quot;.\${BOOT_CLEANED_WIM}&quot;
+
+Write-Host &quot;After&quot;
+dir
                 </code>
             </pre>
         </div>

--- a/steps/checkinputparameterwindowsfolderonsambaforwinpekickstartonwindowsworker/script.txt
+++ b/steps/checkinputparameterwindowsfolderonsambaforwinpekickstartonwindowsworker/script.txt
@@ -3,16 +3,16 @@ if ( -Not ${{isWinPEKickstart}} ) {
     exit 1
 }
 
-if ( {windowsFolderOnSamba} -eq "windows10" ) {
+if ( "{windowsFolderOnSamba}" -eq "windows10" ) {
     if ( (-Not ${{isWin10Bios}}) -And (-Not ${{isWin10Uefi}}) ) {
         Write-Host "Please set one of 'isWin10Bios' or 'isWin10Uefi' to true to install Win10."
         exit 1
     }
 }
 
-if (( {windowsFolderOnSamba} -eq "windows2016" ) -Or
-    ( {windowsFolderOnSamba} -eq "windows2019" ) -Or
-    ( {windowsFolderOnSamba} -eq "windows2022" )) {
+if (( "{windowsFolderOnSamba}" -eq "windows2016" ) -Or
+    ( "{windowsFolderOnSamba}" -eq "windows2019" ) -Or
+    ( "{windowsFolderOnSamba}" -eq "windows2022" )) {
 
     if ( (-Not ${{isWinServerBios}}) -And (-Not ${{isWinServerUefi}}) ) {
         Write-Host "Please set one of 'isWinServerBios' or 'isWinServerUefi' to true to install Windows Server."

--- a/steps/checkmaximumlengthofwin10hostnameonwindowsworker/script.txt
+++ b/steps/checkmaximumlengthofwin10hostnameonwindowsworker/script.txt
@@ -6,10 +6,10 @@ if ( ${{isWin10Bios}} -or ${{isWin10Uefi}} ) {
     $MAX_LENGTH = 15
     
     if ( $LENGTH -gt $MAX_LENGTH ) {
-        Write-Host "Length of hostname ${LENGTH} for Win10 can't be more than ${MAX_LENGTH}."
+        Write-Host "Length of hostname `"${HOSTNAME}`"  for Win10 is ${LENGTH} and can't be more than ${MAX_LENGTH}."
         false
     } else {
-        Write-Host "Length of hostname ${LENGTH} is less than or equal to ${MAX_LENGTH}."
+        Write-Host "Length of hostname `"${HOSTNAME}`" for Win10 is ${LENGTH} which is less than or equal to ${MAX_LENGTH}."
     }
     
 } else {

--- a/steps/confirmplainwinpebiosisoexistsonwindowsworker/README.md
+++ b/steps/confirmplainwinpebiosisoexistsonwindowsworker/README.md
@@ -1,4 +1,4 @@
-Checks if the WinPE plain BIOS ISO `C:\attuneautomationworker/winpe_plain_bios.iso` exists.
+Checks if the WinPE plain BIOS ISO `C:\attuneautomationworker\winpe_plain_bios.iso` exists.
 
 If it does not, a message will be printed to ask the user to run the WinPE BIOS ISO creation blueprint `Create Windows PE (WinPE) Plain ISO on Windows Worker`.
 

--- a/steps/confirmplainwinpebiosisoexistsonwindowsworker/metadata.json
+++ b/steps/confirmplainwinpebiosisoexistsonwindowsworker/metadata.json
@@ -2,7 +2,7 @@
     "actionOnStepFail": null, 
     "enabled": true, 
     "externalUuid4": "36e0c0c0-7ed2-4e6a-b58f-5eb737d361fe", 
-    "interpreter": 1, 
+    "interpreter": 2, 
     "interpreterCommand": "", 
     "interpreterScriptExt": null, 
     "interpreterScriptSyntax": "", 
@@ -11,6 +11,6 @@
     "osCredKey": "automationworkerwindowsuseradministrator", 
     "serverKey": "automationworkerwindowsnode", 
     "successExitCode": 0, 
-    "timeout": 5, 
+    "timeout": 60, 
     "type": "com.servertribe.attune.tuples.StepWinRmTuple"
 }

--- a/steps/confirmplainwinpeuefiisoexistsonwindowsworker/README.md
+++ b/steps/confirmplainwinpeuefiisoexistsonwindowsworker/README.md
@@ -1,4 +1,4 @@
-Checks if the WinPE plain BIOS ISO `C:\attuneautomationworker/winpe_plain_uefi.iso` exists.
+Checks if the WinPE plain BIOS ISO `C:\attuneautomationworker\winpe_plain_uefi.iso` exists.
 
 If it does not, a message will be printed to ask the user to run the WinPE UEFI ISO creation blueprint `Create Windows PE (WinPE) Plain ISO on Windows Worker`.
 

--- a/steps/confirmplainwinpeuefiisoexistsonwindowsworker/metadata.json
+++ b/steps/confirmplainwinpeuefiisoexistsonwindowsworker/metadata.json
@@ -2,7 +2,7 @@
     "actionOnStepFail": "stop", 
     "enabled": true, 
     "externalUuid4": "3ab4ef45-d392-4e33-80ef-521995396e59", 
-    "interpreter": 1, 
+    "interpreter": 2, 
     "interpreterCommand": "", 
     "interpreterScriptExt": null, 
     "interpreterScriptSyntax": "", 
@@ -11,6 +11,6 @@
     "osCredKey": "automationworkerwindowsuseradministrator", 
     "serverKey": "automationworkerwindowsnode", 
     "successExitCode": 0, 
-    "timeout": 5, 
+    "timeout": 60, 
     "type": "com.servertribe.attune.tuples.StepWinRmTuple"
 }

--- a/steps/copyandrenamewinpebiosisoonwindowsworker/script.txt
+++ b/steps/copyandrenamewinpebiosisoonwindowsworker/script.txt
@@ -11,7 +11,7 @@ if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
     }
 
     Copy-Item -Path "winpe_plain_bios.iso" `
-        -Destination "${BUILD_FOLDER}"
+        -Destination "${BUILD_FOLDER}\winpe.iso"
     
 } else {
     Write-Host "Skipping for UEFI ISO creation."

--- a/steps/copyandrenamewinpeuefiisoonwindowsworker/script.txt
+++ b/steps/copyandrenamewinpeuefiisoonwindowsworker/script.txt
@@ -11,7 +11,7 @@ if ( ${{isWin10Uefi}} -Or ${{isWinServerUefi}} ) {
     }
 
     Copy-Item -Path "winpe_plain_uefi.iso" `
-        -Destination "${BUILD_FOLDER}"
+        -Destination "${BUILD_FOLDER}\winpe.iso"
     
 } else {
     Write-Host "Skipping for BIOS ISO creation."

--- a/steps/copydriversdropinfoldertobootwimonwindowsworker/script.txt
+++ b/steps/copydriversdropinfoldertobootwimonwindowsworker/script.txt
@@ -7,7 +7,7 @@ Set-Location "${BUILD_DIR}\${WinPE_BootImageDir}"
 
 $DRIVERS="drivers"
 if ( -Not (Test-Path "${DRIVERS}") ) {
-  New-Item DRIVERS -ItemType Directory
+  New-Item "${DRIVERS}" -ItemType Directory
 }
 
 $DRIVERS_DROP_IN_FOLDER="C:\attuneautomationworker\drivers-{newOsNode.fqn}"

--- a/steps/createbootwimmountfolderonwindowsworker/script.txt
+++ b/steps/createbootwimmountfolderonwindowsworker/script.txt
@@ -6,5 +6,5 @@ Set-Location "${BUILD_DIR}"
 $WinPE_BootImageDir="WinPE_BootImageDir"
 
 if ( -Not (Test-Path "${WinPE_BootImageDir}") ) {
-  New-Item "${WinPE_BootImageDi}" -ItemType Directory
+  New-Item "${WinPE_BootImageDir}" -ItemType Directory
 }

--- a/steps/createpostinstallwimwindowsimageonwindowsworker/script.txt
+++ b/steps/createpostinstallwimwindowsimageonwindowsworker/script.txt
@@ -5,8 +5,8 @@ Set-Location $BUILD_DIR
 
 Write-Host "We are in ${BUILD_DIR}"
 
-SOURCE="post_install_wim"
-WIMFILE="post_install.wim"
+$SOURCE="post_install_wim"
+$WIMFILE="post_install.wim"
 
 Write-Host "Creating ${WIMFILE} from directory ${SOURCE}."
 

--- a/steps/modifywinpebootwimonwindowsworker/metadata.json
+++ b/steps/modifywinpebootwimonwindowsworker/metadata.json
@@ -21,6 +21,10 @@
         {
             "order": 150, 
             "stepKey": "wimlibunmountbootwimonwindowsworker"
+        }, 
+        {
+            "order": 200, 
+            "stepKey": "overwritebootwimwithbootcleanedwimonwindowsworker"
         }
     ], 
     "name": "Modify WinPE boot.wim on Windows Worker", 

--- a/steps/mountbootwiminbuildwinpeisoonwindowsworker/README.md
+++ b/steps/mountbootwiminbuildwinpeisoonwindowsworker/README.md
@@ -1,1 +1,1 @@
-Mounts `C:\attuneautomationworker\build-winpe-iso\winpe_staging\SOURCES\BOOT.WIM` to `C:\attuneautomationworker\build-winpe-iso\WinPE_BootImageDir` using `Dism`.
+Mounts `C:\attuneautomationworker\build-winpe-iso\winpe_staging\SOURCES\BOOT.WIM` to `C:\attuneautomationworker\build-winpe-iso\WinPE_BootImageDir` using `Dism` on Windows Worker.

--- a/steps/mountbootwimonwindowsworker/README.md
+++ b/steps/mountbootwimonwindowsworker/README.md
@@ -1,1 +1,1 @@
-In the `C:\attuneautomationworker\build-{newOsNode.fqn}` folder, mounts `winpe_staging\SOURCES\BOOT.WIM` to `WinPE_BootImageDir` on Windows Worker.
+In the `C:\attuneautomationworker\build-{newOsNode.fqn}` folder, mounts `winpe_staging\SOURCES\BOOT.WIM` to `WinPE_BootImageDir` using `Dism` on Windows Worker.

--- a/steps/mountbootwimonwindowsworker/script.txt
+++ b/steps/mountbootwimonwindowsworker/script.txt
@@ -3,21 +3,10 @@ $BUILD_DIR="$ISO_BUILD\build-{newOsNode.fqn}"
 
 Set-Location $BUILD_DIR
 
-$scriptContent=@"
-wimmountrw winpe_staging/SOURCES/BOOT.WIM WinPE_BootImageDir
-"@
-
-# Replace CRLF with LF
-$scriptContent = $scriptContent.replace("`r`n","`n")
-    
-$FILE = "attune_wsl_mount_boot_wim.sh"
-
-Set-Content -Path $FILE -NoNewline -Value $scriptContent
-
-wsl -d Ubuntu --user {wsl2AutomationWorkerLinuxUser.user} --exec bash "${FILE}"
-
+Dism /Mount-Image /ImageFile:"./winpe_staging/SOURCES/BOOT.WIM" `
+  /Index:1 `
+  /MountDir:"./WinPE_BootImageDir"
+  
 if ($LASTEXITCODE -ne 0) {
     Write-Error 'Failed to mount BOOT.WIM'
 }
-  
-Remove-Item "${FILE}"

--- a/steps/movepostsetuppowershellscripttopostinstallwimfolderonwindowsworker/script.txt
+++ b/steps/movepostsetuppowershellscripttopostinstallwimfolderonwindowsworker/script.txt
@@ -6,7 +6,7 @@ Set-Location $BUILD_DIR
 $POST_INSTALL_WIM_FOLDER = "post_install_wim"
 
 if ( -Not (Test-Path "${POST_INSTALL_WIM_FOLDER}") ) {
-  New-Item "${POST_INSTALL_WIM_FOLDER} -ItemType Directory
+  New-Item "${POST_INSTALL_WIM_FOLDER}" -ItemType Directory
 }
 
 Move-Item -Path .\post_install_setup.ps1 `

--- a/steps/movestartnetcmdtobootwimonwindowsworker/script.txt
+++ b/steps/movestartnetcmdtobootwimonwindowsworker/script.txt
@@ -3,5 +3,9 @@ $BUILD_DIR="${ISO_BUILD}\build-{newOsNode.fqn}"
 
 Set-Location "${BUILD_DIR}"
 
+$DESTINATION_FILE = ".\WinPE_BootImageDir\Windows\System32\startnet.cmd"
+
+Remove-Item "${DESTINATION_FILE}"
+
 Move-Item -Path ".\startnet.cmd" `
-    -Destination ".\WinPE_BootImageDir\Windows\System32"
+    -Destination "${DESTINATION_FILE}"

--- a/steps/overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker/README.md
+++ b/steps/overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker/README.md
@@ -1,0 +1,3 @@
+Overwrites `BOOT.WIM` with `BOOT_CLEANED.WIM` and deletes `BOOT_CLEANED.WIM`.
+
+This is relative to the `C:\attuneautomationworker\build-winpe-iso\winpe_staging\SOURCES` folder.

--- a/steps/overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker/metadata.json
+++ b/steps/overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker/metadata.json
@@ -1,16 +1,16 @@
 {
-    "actionOnStepFail": null, 
+    "actionOnStepFail": "stop", 
     "enabled": true, 
-    "externalUuid4": "a545bd46-81c5-4c07-a04c-9c826c41acaf", 
+    "externalUuid4": "b3e53b17-4103-4944-b7b1-fea0742adbdf", 
     "interpreter": 2, 
     "interpreterCommand": "", 
     "interpreterScriptExt": null, 
     "interpreterScriptSyntax": "", 
-    "key": "checkinputparameterkickstartedbootloaderisuefiforwinpekickstartonwindowsworker", 
-    "name": "Check Input Parameter kickstartedBootLoaderIsUefi for WinPE Kickstart on Windows Worker", 
+    "key": "overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker", 
+    "name": "Overwrite BOOT.WIM with BOOT_CLEANED.WIM from build-winpe-iso on Windows Worker", 
     "osCredKey": "automationworkerwindowsuseradministrator", 
     "serverKey": "automationworkerwindowsnode", 
     "successExitCode": 0, 
-    "timeout": 60, 
+    "timeout": 120, 
     "type": "com.servertribe.attune.tuples.StepWinRmTuple"
 }

--- a/steps/overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker/script.txt
+++ b/steps/overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker/script.txt
@@ -1,5 +1,5 @@
 $ISO_BUILD="C:\attuneautomationworker"
-$WINPE_STAGING_SOURCES_DIR="$ISO_BUILD\build-{newOsNode.fqn}\winpe_staging\SOURCES"
+$WINPE_STAGING_SOURCES_DIR="$ISO_BUILD\build-winpe-iso\winpe_staging\SOURCES"
 
 Set-Location "${WINPE_STAGING_SOURCES_DIR}"
 

--- a/steps/overwritebootwimwithbootcleanedwimonwindowsworker/metadata.json
+++ b/steps/overwritebootwimwithbootcleanedwimonwindowsworker/metadata.json
@@ -1,7 +1,7 @@
 {
     "actionOnStepFail": "stop", 
     "enabled": true, 
-    "externalUuid4": "b3e53b17-4103-4944-b7b1-fea0742adbdf", 
+    "externalUuid4": "65b4f25b-02a5-4572-850c-0dc3a701cfc1", 
     "interpreter": 2, 
     "interpreterCommand": "", 
     "interpreterScriptExt": null, 

--- a/steps/performdeletesetupexefromwinpestagingbootwimonwindowsworker/metadata.json
+++ b/steps/performdeletesetupexefromwinpestagingbootwimonwindowsworker/metadata.json
@@ -24,7 +24,7 @@
         }, 
         {
             "order": 200, 
-            "stepKey": "overwritebootwimwithbootcleanedwimonwindowsworker"
+            "stepKey": "overwritebootwimwithbootcleanedwimfrombuildwinpeisoonwindowsworker"
         }
     ], 
     "name": "Perform Delete setup.exe from winpe_staging boot.wim on Windows Worker", 

--- a/steps/wimlibunmountbootwimonwindowsworker/README.md
+++ b/steps/wimlibunmountbootwimonwindowsworker/README.md
@@ -1,3 +1,17 @@
-Unmounts `C:\attuneautomationworker\build-{newOsNode.fqn}\WinPE_BootImageDir` using `wimunmount` on Windows Worker with WSL2.
+Unmounts `C:\attuneautomationworker\build-{newOsNode.fqn}\WinPE_BootImageDir` using `Dism`.
 
-This will write out changes back into `winpe_staging\SOURCES\BOOT.WIM`.
+This will write out changes back into `C:\attuneautomationworker\winpe_staging\SOURCES\BOOT.WIM`.
+
+Then a compressed version of `BOOT.WIM` is generated called `BOOT_CLEANED.WIM`.
+
+Make sure there is no Windows File Explorer open at the mount directory.
+
+If there is the unmount will fail and you need to run these commands to unmount it:
+```
+$ISO_BUILD="C:\attuneautomationworker"
+$BUILD_DIR="$ISO_BUILD\build-{newOsNode.fqn}"
+
+Set-Location $BUILD_DIR
+
+Dism /Unmount-Image /MountDir:"./WinPE_BootImageDir" /discard
+```

--- a/steps/wimlibunmountbootwimonwindowsworker/script.txt
+++ b/steps/wimlibunmountbootwimonwindowsworker/script.txt
@@ -5,21 +5,18 @@ Set-Location "${BUILD_DIR}"
 
 $WinPE_BootImageDir = "WinPE_BootImageDir"
 
-$scriptContent=@"
-wimunmount "${WinPE_BootImageDir}" --commit --check --rebuild
-"@
-
-# Replace CRLF with LF
-$scriptContent = $scriptContent.replace("`r`n","`n")
+Dism /Image:"./WinPE_BootImageDir" `
+    /cleanup-image `
+    /StartComponentCleanup `
+    /ResetBase
     
-$FILE = "attune_wsl_unmount_boot_wim.sh"
+# Unmount the WinPE_BootImageDir folder back into BOOT.WIM
+Dism /Unmount-Image /MountDir:"./WinPE_BootImageDir" /Commit
 
-Set-Content -Path $FILE -NoNewline -Value $scriptContent
-
-wsl -d Ubuntu --user {wsl2AutomationWorkerLinuxUser.user} --exec bash "${FILE}"
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Error 'Failed to unmount $BUILD_DIR\${WinPE_BootImageDir}'
-}
-  
-Remove-Item "${FILE}"
+# Generate a compressed version of BOOT.WIM called BOOT_CLEANED.WIM
+Dism /Export-Image /SourceImageFile:"./winpe_staging/SOURCES/BOOT.WIM" `
+  /SourceIndex:1 `
+  /DestinationImageFile:"./winpe_staging/SOURCES/BOOT_CLEANED.WIM" `
+  /Compress:max `
+  /Bootable `
+  /CheckIntegrity


### PR DESCRIPTION
Fixed bugs in blueprint `Create Windows autounattend WinPE ISO on Windows Worker`.

closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/86
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/87
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/88
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/89
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/90
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/91
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/92
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/93

![image](https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/assets/14309370/886bac31-467e-46e0-9fcd-81c9699fc3a5)
