### PR TITLE
AUSTA-317: Fix WinPE Windows Worker Kickstarts "net use" Prompts for Username

### DIFF
--- a/docs/Create-Windows-autounattend-WinPE-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-autounattend-WinPE-ISO-on-Windows-Worker.html
@@ -2042,9 +2042,9 @@ if (${{kickstartedBootLoaderIsUefi}}) {
     
     $WinPE_amd64=&quot;WinPE_amd64&quot;
     
-    Dism /Mount-Image /ImageFile:&quot;./${WinPE_amd64}/sources/boot.wim&quot; `
+    Dism /Mount-Image /ImageFile:&quot;.\${WinPE_amd64}\media\sources\boot.wim&quot; `
       /Index:1 `
-      /MountDir:&quot;./WinPE_BootImageDir&quot;
+      /MountDir:&quot;.\WinPE_BootImageDir&quot;
       
     if ($LASTEXITCODE -ne 0) {
         Write-Error &#x27;Failed to mount BOOT.WIM&#x27;

--- a/files/winpestartnetcmd/contents/startnet.cmd
+++ b/files/winpestartnetcmd/contents/startnet.cmd
@@ -47,7 +47,7 @@ REM Use the net use command's output as a means to test whether the Samba
 REM server is up.
 
 :mountsamba
-net use Z: \\%sambaIPaddress%\share | find "successfully" > nul
+net use Z: \\%sambaIPaddress%\share /user:Everyone "" | find "successfully" > nul
 if errorlevel 1 (
     echo mount failed, waiting for retry...
     ping localhost -n 2 >NUL

--- a/steps/mountuefibootwimonwindowsworker/script.txt
+++ b/steps/mountuefibootwimonwindowsworker/script.txt
@@ -6,9 +6,9 @@ if (${{kickstartedBootLoaderIsUefi}}) {
     
     $WinPE_amd64="WinPE_amd64"
     
-    Dism /Mount-Image /ImageFile:"./${WinPE_amd64}/sources/boot.wim" `
+    Dism /Mount-Image /ImageFile:".\${WinPE_amd64}\media\sources\boot.wim" `
       /Index:1 `
-      /MountDir:"./WinPE_BootImageDir"
+      /MountDir:".\WinPE_BootImageDir"
       
     if ($LASTEXITCODE -ne 0) {
         Write-Error 'Failed to mount BOOT.WIM'


### PR DESCRIPTION
Modified `startnet.cmd` to use `Everyone` as the username to work with Windows Worker samba shares.

closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/100.
closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/99.