### PR TITLE
AUSTA-318: Bug in step "Overwrite BOOT.WIM with BOOT_CLEANED.WIM on Windows Worker"

### DIFF
--- a/docs/Create-Windows-autounattend-WinPE-ISO-on-Windows-Worker.html
+++ b/docs/Create-Windows-autounattend-WinPE-ISO-on-Windows-Worker.html
@@ -2005,7 +2005,7 @@ if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
                     <div class="row">
                         <div class="description col px-0">
                             <p>
-                                <p>In the <code>C:\attuneautomationworker\build-{newOsNode.fqn}</code> folder, mounts <code>".\WinPE_amd64\sources\boot.wim</code> to <code>WinPE_BootImageDir</code> using <code>Dism</code> on Windows Worker.</p>
+                                <p>In the <code>C:\attuneautomationworker\build-{newOsNode.fqn}</code> folder, mounts <code>".\WinPE_amd64\media\sources\boot.wim</code> to <code>WinPE_BootImageDir</code> using <code>Dism</code> on Windows Worker.</p>
                             </p>
                         </div>
                     </div>
@@ -2451,7 +2451,7 @@ Dism /Unmount-Image /MountDir:&quot;./WinPE_BootImageDir&quot; /Commit
                                 <p>A compressed version of <code>BOOT.WIM</code> is generated called <code>BOOT_CLEANED.WIM</code>.</p>
 <p>Relative to the <code>C:\attuneautomationworker\build-{newOsNode.fqn}</code> folder:
 1. For BIOS boots compresses <code>.\winpe_staging\SOURCES\BOOT.WIM</code> to <code>.\winpe_staging\SOURCES\BOOT_CLEANED.WIM</code>.
-2. For UEFI boots compresses <code>.\WinPE_amd64\sources\boot.wim</code> to <code>.\WinPE_amd64\sources\boot_cleaned.wim</code>.</p>
+2. For UEFI boots compresses <code>.\WinPE_amd64\media\sources\boot.wim</code> to <code>.\WinPE_amd64\sources\boot_cleaned.wim</code>.</p>
                             </p>
                         </div>
                     </div>
@@ -2489,8 +2489,8 @@ if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
     $SourceImageFile = &quot;.\winpe_staging\SOURCES\BOOT.WIM&quot;
     $DestinationImageFile = &quot;.\winpe_staging\SOURCES\BOOT_CLEANED.WIM&quot;
 } elseif (${{kickstartedBootLoaderIsUefi}}) {
-    $SourceImageFile = &quot;.\WinPE_amd64\sources\boot.wim&quot;
-    $DestinationImageFile = &quot;.\WinPE_amd64\sources\boot_cleaned.wim&quot;
+    $SourceImageFile = &quot;.\WinPE_amd64\media\sources\boot.wim&quot;
+    $DestinationImageFile = &quot;.\WinPE_amd64\media\sources\boot_cleaned.wim&quot;
 } else {
     Write-Host &quot;Unknown boot method&quot;
     exit 1
@@ -2564,7 +2564,7 @@ $ISO_BUILD=&quot;C:\attuneautomationworker&quot;
 if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
     $WINPE_STAGING_SOURCES_DIR=&quot;$ISO_BUILD\build-{newOsNode.fqn}\winpe_staging\SOURCES&quot;
 } elseif (${{kickstartedBootLoaderIsUefi}}) {
-    $WINPE_STAGING_SOURCES_DIR=&quot;$ISO_BUILD\build-{newOsNode.fqn}\WinPE_amd64\sources&quot;
+    $WINPE_STAGING_SOURCES_DIR=&quot;$ISO_BUILD\build-{newOsNode.fqn}\WinPE_amd64\media\sources&quot;
 } else {
     Write-Host &quot;Unknown boot method&quot;
     exit 1
@@ -2837,12 +2837,9 @@ if (${{kickstartedBootLoaderIsUefi}}) {
             <pre>
                 <code class="language-sql py-0">
 if {kickstartedBootLoaderIsUefi}==true (
-    echo b
 
     call &quot;C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\DandISetEnv.bat&quot; dir
     dir
-    
-    echo c
     
     cd C:\attuneautomationworker\build-{newOsNode.fqn}
     dir

--- a/steps/createuefibootwinpeisofromwinpeamd64onwindowsworker/script.txt
+++ b/steps/createuefibootwinpeisofromwinpeamd64onwindowsworker/script.txt
@@ -1,10 +1,7 @@
 if {kickstartedBootLoaderIsUefi}==true (
-    echo b
 
     call "C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\DandISetEnv.bat" dir
     dir
-    
-    echo c
     
     cd C:\attuneautomationworker\build-{newOsNode.fqn}
     dir

--- a/steps/mountuefibootwimonwindowsworker/README.md
+++ b/steps/mountuefibootwimonwindowsworker/README.md
@@ -1,1 +1,1 @@
-In the `C:\attuneautomationworker\build-{newOsNode.fqn}` folder, mounts `".\WinPE_amd64\sources\boot.wim` to `WinPE_BootImageDir` using `Dism` on Windows Worker.
+In the `C:\attuneautomationworker\build-{newOsNode.fqn}` folder, mounts `".\WinPE_amd64\media\sources\boot.wim` to `WinPE_BootImageDir` using `Dism` on Windows Worker.

--- a/steps/overwritebootwimwithbootcleanedwimonwindowsworker/script.txt
+++ b/steps/overwritebootwimwithbootcleanedwimonwindowsworker/script.txt
@@ -3,7 +3,7 @@ $ISO_BUILD="C:\attuneautomationworker"
 if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
     $WINPE_STAGING_SOURCES_DIR="$ISO_BUILD\build-{newOsNode.fqn}\winpe_staging\SOURCES"
 } elseif (${{kickstartedBootLoaderIsUefi}}) {
-    $WINPE_STAGING_SOURCES_DIR="$ISO_BUILD\build-{newOsNode.fqn}\WinPE_amd64\sources"
+    $WINPE_STAGING_SOURCES_DIR="$ISO_BUILD\build-{newOsNode.fqn}\WinPE_amd64\media\sources"
 } else {
     Write-Host "Unknown boot method"
     exit 1

--- a/steps/wimlibcompressbootwimonwindowsworker/README.md
+++ b/steps/wimlibcompressbootwimonwindowsworker/README.md
@@ -2,4 +2,4 @@ A compressed version of `BOOT.WIM` is generated called `BOOT_CLEANED.WIM`.
 
 Relative to the `C:\attuneautomationworker\build-{newOsNode.fqn}` folder:
 1. For BIOS boots compresses `.\winpe_staging\SOURCES\BOOT.WIM` to `.\winpe_staging\SOURCES\BOOT_CLEANED.WIM`.
-2. For UEFI boots compresses `.\WinPE_amd64\sources\boot.wim` to `.\WinPE_amd64\sources\boot_cleaned.wim`.
+2. For UEFI boots compresses `.\WinPE_amd64\media\sources\boot.wim` to `.\WinPE_amd64\sources\boot_cleaned.wim`.

--- a/steps/wimlibcompressbootwimonwindowsworker/script.txt
+++ b/steps/wimlibcompressbootwimonwindowsworker/script.txt
@@ -7,8 +7,8 @@ if ( ${{isWin10Bios}} -Or ${{isWinServerBios}} ) {
     $SourceImageFile = ".\winpe_staging\SOURCES\BOOT.WIM"
     $DestinationImageFile = ".\winpe_staging\SOURCES\BOOT_CLEANED.WIM"
 } elseif (${{kickstartedBootLoaderIsUefi}}) {
-    $SourceImageFile = ".\WinPE_amd64\sources\boot.wim"
-    $DestinationImageFile = ".\WinPE_amd64\sources\boot_cleaned.wim"
+    $SourceImageFile = ".\WinPE_amd64\media\sources\boot.wim"
+    $DestinationImageFile = ".\WinPE_amd64\media\sources\boot_cleaned.wim"
 } else {
     Write-Host "Unknown boot method"
     exit 1


### PR DESCRIPTION
Fxed the incorrect paths in steps `wimlib Compress boot.wim on Windows Worker` and `Overwrite BOOT.WIM with BOOT_CLEANED.WIM on Windows Worker` for the case when `kickstartedBootLoaderIsUefi` is `true`.

closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/102.