### PR TITLE
	AUSTA-311: Step "Delete Skeleton WinPE_amd64 Folder on Windows Worker" modified to run for both BIOS and UEFI boot methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,6 @@ Performs basic tests for the built node.
 
 Sets up a Samba server with the folder at `${HOME}/windows_iso_data_for_winpe`.
 
-### Unmount and Remove ISO From Node for Feature Install
-
-
 ### Setup Skeleton WinPE_amd64 Folder on Windows Worker
 
 Sets up the "plain" WinPE skeleton files on Windows Worker at `C:\WinPE_amd64`.
@@ -222,6 +219,9 @@ Sets up the "plain" WinPE skeleton files on Windows Worker at `C:\WinPE_amd64`.
 This folder can be copied and then it's `.\media\sources\boot.wim` file can be modified for an automated unattended Windows install.
 
 This folder works for both BIOS and UEFI boot methods.
+
+### Unmount and Remove ISO From Node for Feature Install
+
 
 
 

--- a/docs/Setup-Skeleton-WinPE_amd64-Folder-on-Windows-Worker.html
+++ b/docs/Setup-Skeleton-WinPE_amd64-Folder-on-Windows-Worker.html
@@ -541,16 +541,10 @@ if (test-Path &quot;${ISO_WILDCARD}&quot; -pathtype leaf) {
         <div class="col px-0">
             <pre>
                 <code class="language-sql py-0">
-if (${{kickstartedBootLoaderIsUefi}}) {
-    
-    $WinPE_amd64=&quot;C:\WinPE_amd64&quot;
-    
-    if ( (Test-Path &quot;${WinPE_amd64}&quot;) ) {
-      Remove-Item -Path &quot;${WinPE_amd64}&quot; -Recurse
-    }
-    
-} else {
-    echo &quot;Skipping for BIOS ISO creation.&quot;
+$WinPE_amd64=&quot;C:\WinPE_amd64&quot;
+
+if ( (Test-Path &quot;${WinPE_amd64}&quot;) ) {
+  Remove-Item -Path &quot;${WinPE_amd64}&quot; -Recurse
 }
                 </code>
             </pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -685,19 +685,6 @@
 
                         <div class="col-12 pt-3 pl-0">
                             <div class="card"
-                                 id="Unmount-and-Remove-ISO-From-Node-for-Feature-Install">
-                                <div class="card-body">
-                                    <a href="Unmount-and-Remove-ISO-From-Node-for-Feature-Install.html">
-                                        <h3 class="card-title">
-                                            Unmount and Remove ISO From Node for Feature Install
-                                        </h3>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="col-12 pt-3 pl-0">
-                            <div class="card"
                                  id="Setup-Skeleton-WinPE_amd64-Folder-on-Windows-Worker">
                                 <div class="card-body">
                                     <a href="Setup-Skeleton-WinPE_amd64-Folder-on-Windows-Worker.html">
@@ -712,6 +699,19 @@
 <p>This folder works for both BIOS and UEFI boot methods.</p>
                                         </p>
                                     </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-12 pt-3 pl-0">
+                            <div class="card"
+                                 id="Unmount-and-Remove-ISO-From-Node-for-Feature-Install">
+                                <div class="card-body">
+                                    <a href="Unmount-and-Remove-ISO-From-Node-for-Feature-Install.html">
+                                        <h3 class="card-title">
+                                            Unmount and Remove ISO From Node for Feature Install
+                                        </h3>
+                                    </a>
                                 </div>
                             </div>
                         </div>

--- a/steps/deleteskeletonwinpeamd64folderonwindowsworker/script.txt
+++ b/steps/deleteskeletonwinpeamd64folderonwindowsworker/script.txt
@@ -1,11 +1,6 @@
-if (${{kickstartedBootLoaderIsUefi}}) {
-    
-    $WinPE_amd64="C:\WinPE_amd64"
-    
-    if ( (Test-Path "${WinPE_amd64}") ) {
-      Remove-Item -Path "${WinPE_amd64}" -Recurse
-    }
-    
-} else {
-    echo "Skipping for BIOS ISO creation."
+$WinPE_amd64="C:\WinPE_amd64"
+
+if ( (Test-Path "${WinPE_amd64}") ) {
+  Remove-Item -Path "${WinPE_amd64}" -Recurse
 }
+    


### PR DESCRIPTION
Step `Delete Skeleton WinPE_amd64 Folder on Windows Worker` modified to run for both BIOS and UEFI boot methods.

closes https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/issues/108.

![image](https://github.com/Attune-Automation/Automate-Windows-Installation-with-autounattend/assets/14309370/17172476-c8a2-437b-af3f-2c67d4583642)
