### PR TITLE
Fix issues identified while Installing Win2022 on Proxmox via Debian worker

### DIFF
--- a/files/postinstallsetuppowershellscript/contents/post_install_setup.ps1
+++ b/files/postinstallsetuppowershellscript/contents/post_install_setup.ps1
@@ -47,12 +47,12 @@ New-Item -Path WSMan:\LocalHost\Listener -Transport HTTPS -Address * `
     -DnsName '${newOsNode.hostname}' `
     -NotAfter (get-date).AddYears(6)).Thumbprint -Force
 
-Restart-Service -Force WinRM
+Enable-WSManCredSSP -Role Server -Force
+
+Stop-Service -Force WinRM
 
 New-NetFirewallRule -DisplayName 'WinRM HTTPS' -Name 'WinRM_HTTPS' `
     -Profile Any -LocalPort 5986 -Protocol TCP
-
-Enable-WSManCredSSP -Role Server -Force
     
 # Enable File Sharing
 Get-NetFirewallRule -DisplayGroup 'File and Printer Sharing' | `

--- a/files/postinstallsetuppowershellscript/contents/post_install_setup.ps1
+++ b/files/postinstallsetuppowershellscript/contents/post_install_setup.ps1
@@ -47,10 +47,12 @@ New-Item -Path WSMan:\LocalHost\Listener -Transport HTTPS -Address * `
     -DnsName '${newOsNode.hostname}' `
     -NotAfter (get-date).AddYears(6)).Thumbprint -Force
 
-Stop-Service -Force WinRM
+Restart-Service -Force WinRM
 
 New-NetFirewallRule -DisplayName 'WinRM HTTPS' -Name 'WinRM_HTTPS' `
     -Profile Any -LocalPort 5986 -Protocol TCP
+
+Enable-WSManCredSSP -Role Server -Force
     
 # Enable File Sharing
 Get-NetFirewallRule -DisplayGroup 'File and Printer Sharing' | `

--- a/files/windowsunattendedconfig/contents/autounattend.xml
+++ b/files/windowsunattendedconfig/contents/autounattend.xml
@@ -128,10 +128,8 @@
 							<Label>System Reserved</Label>
 							<Order>1</Order>
 							<PartitionID>1</PartitionID>
-							<TypeID>0x27</TypeID>
 						</ModifyPartition>
 						<ModifyPartition wcm:action="add">
-							<Active>true</Active>
 							<Format>NTFS</Format>
 							<Label>OS</Label>
 							<Letter>C</Letter>

--- a/steps/copydriversdropinfolderonmacosorlinuxworker/metadata.json
+++ b/steps/copydriversdropinfolderonmacosorlinuxworker/metadata.json
@@ -1,5 +1,5 @@
 {
-    "actionOnStepFail": null, 
+    "actionOnStepFail": "stop", 
     "enabled": true, 
     "externalUuid4": "018c74c8-c550-49ae-8a83-6d086508a6c4", 
     "interpreter": 1, 

--- a/steps/copydriversdropinfolderonmacosorlinuxworker/script.txt
+++ b/steps/copydriversdropinfolderonmacosorlinuxworker/script.txt
@@ -3,12 +3,12 @@ cd {automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}
 DRIVERS_DROP_IN_FOLDER="{automationWorkerLinuxBaseDirectory}/drivers-{newOsNode.fqn}"
 DESTINATION_DRIVERS_FOLDER="drivers"
 
-mkdir --verbose "${DESTINATION_DRIVERS_FOLDER}"
+mkdir -v "${DESTINATION_DRIVERS_FOLDER}"
 
 if [ -d "${DRIVERS_DROP_IN_FOLDER}" ]
 then
 
-    cp --verbose --recursive "${DRIVERS_DROP_IN_FOLDER}"/* \
+    cp -v -R "${DRIVERS_DROP_IN_FOLDER}"/* \
         "${DESTINATION_DRIVERS_FOLDER}"
 else
     echo "Drivers drop in folder ${DRIVERS_DROP_IN_FOLDER} does not exist. No drivers copied."

--- a/steps/copyefisysnopromptbinintoefisysbinonmacosorlinuxworker/metadata.json
+++ b/steps/copyefisysnopromptbinintoefisysbinonmacosorlinuxworker/metadata.json
@@ -1,5 +1,5 @@
 {
-    "actionOnStepFail": null, 
+    "actionOnStepFail": "stop", 
     "enabled": true, 
     "externalUuid4": "da0b91ff-a1a7-4cc8-bd4b-9d44bbdf15b3", 
     "interpreter": 1, 

--- a/steps/copyefisysnopromptbinintoefisysbinonmacosorlinuxworker/script.txt
+++ b/steps/copyefisysnopromptbinintoefisysbinonmacosorlinuxworker/script.txt
@@ -4,7 +4,7 @@ then
     cd {automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}
     cd efi/microsoft/boot/
     
-    cp --verbose efisys_noprompt.bin efisys.bin
+    cp -v efisys_noprompt.bin efisys.bin
 else
     echo "Skipping for BIOS ISO creation."
 fi

--- a/steps/createbiosbootisoonmacosorlinuxworker/metadata.json
+++ b/steps/createbiosbootisoonmacosorlinuxworker/metadata.json
@@ -1,5 +1,5 @@
 {
-    "actionOnStepFail": null, 
+    "actionOnStepFail": "stop", 
     "enabled": true, 
     "externalUuid4": "4f1f567c-ec82-4c18-b14d-208a79891b31", 
     "interpreter": 1, 

--- a/steps/createbiosbootisoonmacosorlinuxworker/script.txt
+++ b/steps/createbiosbootisoonmacosorlinuxworker/script.txt
@@ -1,6 +1,6 @@
 cd "{automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}"
 
-if {isWin10Bios} || {isWinServerBios} 
+if {isWin10Bios} || {isWinServerBios}
 then
     if uname | \
         grep -iq "darwin"
@@ -8,13 +8,12 @@ then
         echo "is macOS"
         export PATH="${HOME}/Parallels/homebrew/bin:$PATH"
         echo "Using $(which xorriso)"
-        
+
         xorriso -as mkisofs \
             -b boot.img \
             -no-emul-boot \
             -c BOOT.CAT \
             -iso-level 3 \
-            -udf \
             -joliet-long \
             -relaxed-filenames \
             -J \
@@ -24,10 +23,10 @@ then
             -V "KS_WIN" \
             -o {automationWorkerLinuxBaseDirectory}/kickstart_{newOsNode.fqn}.iso \
             .
-            
+
     else
         echo "not macOS"
-        
+
         mkisofs \
             -b boot.img \
             -no-emul-boot \
@@ -45,7 +44,7 @@ then
             -o {automationWorkerLinuxBaseDirectory}/kickstart_{newOsNode.fqn}.iso \
             .
     fi
-        
+
 else
     echo "Skipping for UEFI boot."
 fi

--- a/steps/deploypostsetuppowershellscriptonmacosorlinux/metadata.json
+++ b/steps/deploypostsetuppowershellscriptonmacosorlinux/metadata.json
@@ -1,7 +1,7 @@
 {
-    "actionOnStepFail": null, 
+    "actionOnStepFail": "stop", 
     "archiveKey": "postinstallsetuppowershellscript", 
-    "deployPath": "{automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}/post_install_wim", 
+    "deployPath": "{automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}", 
     "enabled": true, 
     "externalUuid4": "2f7c99d3-6a08-463f-8a42-d509778486a2", 
     "key": "deploypostsetuppowershellscriptonmacosorlinux", 

--- a/steps/extractwindowsbootimgonmacosorlinuxworker/metadata.json
+++ b/steps/extractwindowsbootimgonmacosorlinuxworker/metadata.json
@@ -1,11 +1,11 @@
 {
-    "actionOnStepFail": null, 
+    "actionOnStepFail": "stop", 
     "enabled": true, 
     "externalUuid4": "9cf17953-e171-4e2c-9e87-98bcdb755777", 
     "interpreter": 1, 
     "key": "extractwindowsbootimgonmacosorlinuxworker", 
     "name": "Extract Windows boot.img on macOS or Linux Worker", 
-    "osCredKey": "automationworkerlinuxuser", 
+    "osCredKey": "automationworkerlinuxuserroot", 
     "serverKey": "automationworkerlinuxnode", 
     "successExitCode": 0, 
     "type": "com.servertribe.attune.tuples.StepSshTuple"

--- a/steps/extractwindowsbootimgonmacosorlinuxworker/script.txt
+++ b/steps/extractwindowsbootimgonmacosorlinuxworker/script.txt
@@ -1,22 +1,49 @@
 if {isWin10Bios} || {isWinServerBios}
 then
 
-    # Extract the boot.img out of the WinPE ISO
+    cd "{automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}"
     
-    cd {automationWorkerLinuxBaseDirectory}/build-{newOsNode.fqn}
-    
-    # Case insensitve globbing
+    # Case insensitive globbing for the ISO filename
     shopt -s nocaseglob
-    
-    # Set the filename of the ISO
-    F=$(ls *.iso)
-    
-    # Get the Boot image offset
-    OFFSET=`isoinfo -d -i $F | grep Bootoff | cut  -c21-`
-    
-    # Extract the boot.img.
-    dd if=$F of=boot.img bs=2048 count=8 skip=$OFFSET
-    
+    isoFile=$(ls *.iso | head -n 1)
+
+    if uname | \
+        grep -iq "darwin"
+    then
+        echo "is macOS"
+        export PATH="${HOME}/Parallels/homebrew/bin:$PATH"
+        echo "Using $(which xorriso)"
+
+        # Get the BIOS boot image LBA from the El Torito catalogue
+        lba=$(xorriso -indev "$isoFile" -report_el_torito plain 2>/dev/null \
+            | awk '/^El Torito boot img/ && /BIOS/ {print $NF; exit}')
+
+    else
+        echo "not macOS"
+        echo "Using $(which isoinfo)"
+
+        if command -v isoinfo >/dev/null 2>&1
+        then
+            echo "genisoimage already installed"
+        else
+            echo "Installing genisoimage..."
+            apt-get update
+            apt-get install -y genisoimage
+        fi
+
+        # Get the BIOS boot image LBA via isoinfo
+        lba=$(isoinfo -d -i "$isoFile" | grep Bootoff | cut -c21-)
+    fi
+
+    if [ -z "$lba" ]
+    then
+        echo "Could not determine boot image offset from $isoFile"
+        exit 1
+    fi
+
+    # Extract the boot image (8 sectors of 2048 bytes = 16 KB)
+    dd if="$isoFile" of=boot.img bs=2048 count=8 skip="$lba"
+
 else
     echo "Skipping for UEFI ISO creation."
 fi

--- a/steps/extractwindowsbootimgonmacosorlinuxworker/script.txt
+++ b/steps/extractwindowsbootimgonmacosorlinuxworker/script.txt
@@ -25,10 +25,27 @@ then
         if command -v isoinfo >/dev/null 2>&1
         then
             echo "genisoimage already installed"
+        
         else
             echo "Installing genisoimage..."
-            apt-get update
-            apt-get install -y genisoimage
+
+            if command -v dnf >/dev/null 2>&1
+            then
+                dnf install -y genisoimage
+                
+            elif command -v yum >/dev/null 2>&1
+            then
+                yum install -y genisoimage
+                
+            elif command -v apt-get >/dev/null 2>&1
+            then
+                apt-get update
+                apt-get install -y genisoimage
+            
+            else
+                echo "No supported package manager found (dnf, yum, apt-get)"
+                exit 1
+            fi
         fi
 
         # Get the BIOS boot image LBA via isoinfo


### PR DESCRIPTION
I updated the Post Install Script to include CredSSP that is required for Win2022 and Win11

There was an issue with the DiskConfiguration in the unattended file that I fixed.

I made some changes for macOS compatibility.

Now the blueprint installs genisoimage on Linux if it's not already installed.